### PR TITLE
Add alert, triggered when cert-manager is down:

### DIFF
--- a/config/observability/kubernetes/monitoring_resources/rules-glbc-prometheusrule.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules-glbc-prometheusrule.yaml
@@ -26,6 +26,15 @@ spec:
             name: DeadMansSwitchAlert
     - name: glbc
       rules:
+        - alert: CertManagerDown
+          annotations:
+            description: "Cert-Manager is down. Either Cert-Manager is not running and failing to become ready, is misconfigured, or the metrics endpoint is not responding."
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/CertManagerDown.adoc
+            summary: Cert-Manager is down
+          expr: "(1-absent(kube_pod_status_ready{pod=~\"cert-manager.*\",condition=\"true\"})) or kube_pod_status_ready{pod=~\"cert-manager.*\",condition=\"true\"} < 1"
+          for: "5m"
+          labels:
+            severity: critical
         - alert: GLBCTargetDown
           annotations:
             description: "The GLBC Prometheus Target is down. Either the GLBC component is not running, is misconfigured, or the metrics endpoint is not responding."

--- a/config/observability/kubernetes/monitoring_resources/rules-glbc.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules-glbc.yaml
@@ -19,6 +19,15 @@ groups:
           name: DeadMansSwitchAlert
   - name: glbc
     rules:
+      - alert: CertManagerDown
+        annotations:
+          description: "Cert-Manager is down. Either Cert-Manager is not running and failing to become ready, is misconfigured, or the metrics endpoint is not responding."
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/CertManagerDown.adoc
+          summary: Cert-Manager is down
+        expr: "(1-absent(kube_pod_status_ready{pod=~\"cert-manager.*\",condition=\"true\"})) or kube_pod_status_ready{pod=~\"cert-manager.*\",condition=\"true\"} < 1"
+        for: "5m"
+        labels:
+          severity: critical
       - alert: GLBCTargetDown
         annotations:
           description: "The GLBC Prometheus Target is down. Either the GLBC component is not running, is misconfigured, or the metrics endpoint is not responding."

--- a/config/observability/kubernetes/monitoring_resources/rules_unit_tests/CertManagerDown_test.yaml
+++ b/config/observability/kubernetes/monitoring_resources/rules_unit_tests/CertManagerDown_test.yaml
@@ -1,0 +1,48 @@
+rule_files:
+  - ../rules-glbc.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      # 0m - 5m container is up
+      # 5m - 20m container is down
+      - series: kube_pod_status_ready{pod="cert-manager",condition="true"}
+        values: "1+0x5 0+0x15"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: CertManagerDown
+        exp_alerts: []
+      - eval_time: 20m
+        alertname: CertManagerDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              pod: cert-manager
+              condition: true
+            exp_annotations:
+              summary: 'Cert-Manager is down'
+              description: 'Cert-Manager is down. Either Cert-Manager is not running and failing to become ready, is misconfigured, or the metrics endpoint is not responding.'
+              runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/CertManagerDown.adoc'
+
+  - interval: 1m
+    input_series:
+      # 0m - 5m container is up
+      # 5m - 20m no time series exists
+      - series: kube_pod_status_ready{pod="cert-manager",condition="true"}
+        values: "1+0x5 stale"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: CertManagerDown
+        exp_alerts: []
+      - eval_time: 20m
+        alertname: CertManagerDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              condition: true
+            exp_annotations:
+              summary: 'Cert-Manager is down'
+              description: 'Cert-Manager is down. Either Cert-Manager is not running and failing to become ready, is misconfigured, or the metrics endpoint is not responding.'
+              runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/CertManagerDown.adoc'

--- a/config/observability/monitoring_resources/common/rules/CertManagerDown.dhall
+++ b/config/observability/monitoring_resources/common/rules/CertManagerDown.dhall
@@ -1,0 +1,33 @@
+let K8s =
+      https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/v6.0.0/package.dhall
+        sha256:532e110f424ea8a9f960a13b2ca54779ddcac5d5aa531f86d82f41f8f18d7ef1
+
+let TimeUnit = ../../dhall/TimeUnit/package.dhall
+
+let Duration = ../../dhall/Duration/package.dhall
+
+let AlertSeverity = ../../dhall/AlertSeverity/package.dhall
+
+let PrometheusOperator =
+      ( https://raw.githubusercontent.com/coralogix/dhall-prometheus-operator/v8.0.0/package.dhall
+          sha256:ebc5f0c5f57d410412c2b7cbb64d0883be648eafc094f0c3e10dba4e6bd46ed4
+      ).v1
+
+in  PrometheusOperator.Rule::{
+    , alert = Some "CertManagerDown"
+    , expr =
+        K8s.IntOrString.String
+          "(1-absent(kube_pod_status_ready{pod=~\"cert-manager.*\",condition=\"true\"})) or kube_pod_status_ready{pod=~\"cert-manager.*\",condition=\"true\"} < 1"
+    , for = Some (Duration.show { amount = 5, unit = TimeUnit.Type.Minutes })
+    , labels = Some
+        (toMap { severity = AlertSeverity.show AlertSeverity.Type.Critical })
+    , annotations = Some
+        ( toMap
+            { summary = "Cert-Manager is down"
+            , description =
+                "Cert-Manager is down. Either Cert-Manager is not running and failing to become ready, is misconfigured, or the metrics endpoint is not responding."
+            , runbook_url =
+                "https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/CertManagerDown.adoc"
+            }
+        )
+    }

--- a/config/observability/monitoring_resources/common/rules/__glbc__.dhall
+++ b/config/observability/monitoring_resources/common/rules/__glbc__.dhall
@@ -1,5 +1,6 @@
 let rules =
-      [ ./GLBCTargetDown.dhall
+      [ ./CertManagerDown.dhall
+      , ./GLBCTargetDown.dhall
       , ./HighDNSLatencyAlert.dhall
       , ./HighDNSProviderErrorRate.dhall
       , ./HighTLSProviderErrorRate.dhall

--- a/config/observability/openshift/monitoring_resources/rules-glbc-prometheusrule.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-glbc-prometheusrule.yaml
@@ -26,6 +26,15 @@ spec:
             name: DeadMansSwitchAlert
     - name: glbc
       rules:
+        - alert: CertManagerDown
+          annotations:
+            description: "Cert-Manager is down. Either Cert-Manager is not running and failing to become ready, is misconfigured, or the metrics endpoint is not responding."
+            runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/CertManagerDown.adoc
+            summary: Cert-Manager is down
+          expr: "(1-absent(kube_pod_status_ready{pod=~\"cert-manager.*\",condition=\"true\"})) or kube_pod_status_ready{pod=~\"cert-manager.*\",condition=\"true\"} < 1"
+          for: "5m"
+          labels:
+            severity: critical
         - alert: GLBCTargetDown
           annotations:
             description: "The GLBC Prometheus Target is down. Either the GLBC component is not running, is misconfigured, or the metrics endpoint is not responding."

--- a/config/observability/openshift/monitoring_resources/rules-glbc.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-glbc.yaml
@@ -19,6 +19,15 @@ groups:
           name: DeadMansSwitchAlert
   - name: glbc
     rules:
+      - alert: CertManagerDown
+        annotations:
+          description: "Cert-Manager is down. Either Cert-Manager is not running and failing to become ready, is misconfigured, or the metrics endpoint is not responding."
+          runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/CertManagerDown.adoc
+          summary: Cert-Manager is down
+        expr: "(1-absent(kube_pod_status_ready{pod=~\"cert-manager.*\",condition=\"true\"})) or kube_pod_status_ready{pod=~\"cert-manager.*\",condition=\"true\"} < 1"
+        for: "5m"
+        labels:
+          severity: critical
       - alert: GLBCTargetDown
         annotations:
           description: "The GLBC Prometheus Target is down. Either the GLBC component is not running, is misconfigured, or the metrics endpoint is not responding."

--- a/docs/observability/runbooks/CertManagerDown.adoc
+++ b/docs/observability/runbooks/CertManagerDown.adoc
@@ -1,0 +1,53 @@
+// begin header
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+:numbered:
+:toc: macro
+:toc-title: pass:[<b>Table of Contents</b>]
+// end header
+= CertManagerDown
+
+toc::[]
+
+== Description
+
+The source of the alert is the `kube_pod_status_ready` metric. It fires when Cert-Manager is not running and failing to become ready, or is misconfigured, or the metrics endpoint is not responding.
+The alert will be triggered if cert-manager fails to become ready for longer than 5min.
+
+== Prerequisites
+
+* * Access to the physical cluster where GLBC should be running.
+
+== Execute/Resolution
+
+. Check the cert-manager component and namespace for indications of problems.
++
+[source,sh]
+----
+kubectl get services -A --field-selector metadata.name=cert-manager
+----
++
+[source,sh]
+----
+kubectl get events -n <a namespace from the output above>
+----
+
+. Check cert-manager logs for any errors.
++
+[source,sh]
+----
+kubectl get services -A --field-selector metadata.name=cert-manager
+----
++
+[source,sh]
+----
+kubectl logs deployment/cert-manager -n <a namespace from the output above>
+----
+
+== Validate
+. Check the alert is no longer firing.

--- a/docs/observability/runbooks/HighTLSProviderErrorRate.adoc
+++ b/docs/observability/runbooks/HighTLSProviderErrorRate.adoc
@@ -30,7 +30,12 @@ is greater than the threshold which is 1%. This usually means, the TLS certifica
 +
 [source,sh]
 ----
-kubectl get events -n kcp32653cc5662de9ab2054113507ac53e657ff4afc2a52926039fbc4cd
+kubectl get services -A --field-selector metadata.name=cert-manager
+----
++
+[source,sh]
+----
+kubectl get events -n <a namespace from the output above>
 ----
 . The following link shows how to https://cert-manager.io/docs/faq/troubleshooting/#troubleshooting-a-failed-certificate-request[Troubleshoot a Failed Certificate Request].
 You will find:

--- a/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
+++ b/docs/observability/runbooks/HighTLSProviderLatencyAlert.adoc
@@ -30,7 +30,12 @@ The alert will be triggered if requests are taking longer than 120 seconds. This
 +
 [source,sh]
 ----
-kubectl get events -n kcp32653cc5662de9ab2054113507ac53e657ff4afc2a52926039fbc4cd
+kubectl get services -A --field-selector metadata.name=cert-manager
+----
++
+[source,sh]
+----
+kubectl get events -n <a namespace from the output above>
 ----
 . The following link shows how to https://cert-manager.io/docs/faq/troubleshooting/#troubleshooting-a-failed-certificate-request[Troubleshoot a Failed Certificate Request].
 You will find:


### PR DESCRIPTION
Closes #402 


## Description of Changes
- Add alert which is triggered when cert-manager is down, fails to become ready, or does not exist.
- Add runbook doc for troubleshooting ideas if alert is triggered.
- Add unit tests to alert.
- Updated commands in two runbooks (TLS alerts runbooks) as the namespace for cert-manager has changed.
