### PR TITLE
Fix lint errors

### DIFF
--- a/pkg/access/RouteAccessor.go
+++ b/pkg/access/RouteAccessor.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kuadrant/kcp-glbc/pkg/reconciler/dns"
 )
 
-//RouteAccessor - placeholder, not yet implemented
+// RouteAccessor - placeholder, not yet implemented
 type RouteAccessor struct {
 	object *routev1.Route
 }

--- a/pkg/log/zap.go
+++ b/pkg/log/zap.go
@@ -160,10 +160,10 @@ func NewRaw(opts ...Opts) *zap.Logger {
 }
 
 // BindFlags will parse the given flagset for zap option flags and set the log options accordingly
-//  zap-encoder: Zap log encoding (one of 'json' or 'console')
-//  zap-log-level:  Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error',
-//			       or any integer value > 0 which corresponds to custom debug levels of increasing verbosity")
-//  zap-stacktrace-level: Zap Level at and above which stacktraces are captured (one of 'info', 'error' or 'panic')
+// zap-encoder: Zap log encoding (one of 'json' or 'console')
+// zap-log-level:  Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error',
+// or any integer value > 0 which corresponds to custom debug levels of increasing verbosity")
+// zap-stacktrace-level: Zap Level at and above which stacktraces are captured (one of 'info', 'error' or 'panic')
 func (o *Options) BindFlags(fs *flag.FlagSet) {
 	// Set Encoder value
 	var encVal encoderFlag
@@ -191,10 +191,10 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 }
 
 // UseFlagOptions configures the logger to use the Options set by parsing zap option flags from the CLI.
-//  opts := zap.Options{}
-//  opts.BindFlags(flag.CommandLine)
-//  flag.Parse()
-//  log := zap.New(zap.UseFlagOptions(&opts))
+// opts := zap.Options{}
+// opts.BindFlags(flag.CommandLine)
+// flag.Parse()
+// log := zap.New(zap.UseFlagOptions(&opts))
 func UseFlagOptions(in *Options) Opts {
 	return func(o *Options) {
 		*o = *in

--- a/pkg/util/workloadMigration/workloadMigration.go
+++ b/pkg/util/workloadMigration/workloadMigration.go
@@ -29,7 +29,7 @@ func Process(obj metav1.Object, queue workqueue.RateLimitingInterface, logger lo
 	gracefulRemoveSoftFinalizers(obj, queue, logger)
 }
 
-//ensureSoftFinalizers ensure all active workload clusters have a soft finalizer set
+// ensureSoftFinalizers ensure all active workload clusters have a soft finalizer set
 func ensureSoftFinalizers(obj metav1.Object, logger logr.Logger) {
 	_, labels := metadata.HasLabelsContaining(obj, WorkloadTargetLabel)
 	for label := range labels {
@@ -49,7 +49,7 @@ func ensureSoftFinalizers(obj metav1.Object, logger logr.Logger) {
 	}
 }
 
-//gracefulRemoveSoftFinalizers any soft finalizers with no active workload cluster should trigger a delayed delete
+// gracefulRemoveSoftFinalizers any soft finalizers with no active workload cluster should trigger a delayed delete
 func gracefulRemoveSoftFinalizers(obj metav1.Object, queue workqueue.RateLimitingInterface, logger logr.Logger) {
 	at := time.Now()
 	at = at.Add((TTL * time.Second) * 2)

--- a/test/support/dns.go
+++ b/test/support/dns.go
@@ -131,13 +131,16 @@ func GetZone(t Test, host string) (Zone, error) {
 		return results, nil
 	}
 	if value, ok := values[host]; ok {
-		json.Unmarshal([]byte(value), &results)
+		err = json.Unmarshal([]byte(value), &results)
+		if err != nil {
+			return nil, err
+		}
 		return results, nil
 	}
 	return results, net.NoSuchHost
 }
 
-//setDNSRecord - do not call this directly - use SetTXTRecord or SetARecord
+// setDNSRecord - do not call this directly - use SetTXTRecord or SetARecord
 func setDNSRecord(t Test, key, value string) error {
 	cfg, err := t.Client().Core().Cluster(GLBCWorkspace).CoreV1().ConfigMaps(ConfigmapNamespace).Get(t.Ctx(), ConfigmapName, metav1.GetOptions{})
 	if err != nil {
@@ -151,7 +154,7 @@ func setDNSRecord(t Test, key, value string) error {
 	return setDNSRecords(t, values)
 }
 
-//setDNSRecords - do not call this directly - use SetTXTRecord or SetARecord
+// setDNSRecords - do not call this directly - use SetTXTRecord or SetARecord
 func setDNSRecords(t Test, values map[string]string) error {
 	_, err := t.Client().Core().Cluster(GLBCWorkspace).CoreV1().ConfigMaps(ConfigmapNamespace).Apply(
 		t.Ctx(),


### PR DESCRIPTION
Updates to fix lint errors since updating the golangci-lint version, see  https://github.com/kcp-dev/kcp-glbc/blob/main/.github/workflows/ci.yaml#L25-L38

Locally you should use:
```
$ go version
go version go1.18.5 linux/amd64
$ golangci-lint version
golangci-lint has version 1.49.0 built from cc2d97f3 on 2022-08-24T10:24:37Z
$ make lint
golangci-lint run ./...
```

