### PR TITLE
Add crc option to local setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHELL := /usr/bin/env bash
 # NUM_CLUSTERS is a total number of kind clusters to be provisioned
 NUM_CLUSTERS ?= 1
 DO_BREW := true
+USE_CRC := false
 KCP_BRANCH := release-0.8
 
 IMAGE_TAG_BASE ?= quay.io/kuadrant/kcp-glbc
@@ -182,6 +183,7 @@ endif
 
 .PHONY: local-setup
 local-setup: export KCP_VERSION=${KCP_BRANCH}
+local-setup: export USE_CRC_CLUSTER=${USE_CRC}
 local-setup: clean kind kcp kustomize helm build ## Setup kcp locally using kind.
 	./utils/local-setup.sh -c ${NUM_CLUSTERS} ${LOCAL_SETUP_FLAGS}
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,17 @@ To verify the resources were created successfully, check the output of the follo
 kubectl get deployment,service,ingress
 ```
 
-### Add CRC cluster (optional)
+### Using CRC sync target (optional)
 
-With a running local setup i.e. you have successfully executed `make local-setup`, you can run the following to create and add a CRC cluster:
+The default local setup uses a single sync target backed by a [kind](https://kind.sigs.k8s.io/) physical cluster, you can alternatively use a [crc](https://crc.dev/crc/) cluster by runnning:
+
+```bash
+make local-setup USE_CRC=true
+```
+
+### Add CRC sync target to existing local setup (optional)
+
+With a running local setup i.e. you have successfully executed `make local-setup`, you can run the following to create and add an additional sync target backed by a [crc](https://crc.dev/crc/) cluster:
 
 ```bash
 ./utils/local-setup-add-crc-cluster.sh

--- a/samples/echo-service/echo.yaml
+++ b/samples/echo-service/echo.yaml
@@ -39,7 +39,7 @@ metadata:
   name: echo
 spec:
   rules:
-    - host:
+    - host: host.whatever.com
       http:
         paths:
           - path: /
@@ -49,8 +49,3 @@ spec:
                 name: echo
                 port:
                   number: 80
-  tls:
-  - hosts:
-      - host.whatever.com
-    secretName: testsecret-tls
-                    

--- a/utils/local-setup-add-crc-cluster.sh
+++ b/utils/local-setup-add-crc-cluster.sh
@@ -45,7 +45,8 @@
 set -e pipefail
 
 TEMP_DIR="./tmp"
-CRC_CLUSTER_NAME=kcp-cluster-crc
+: ${CRC_CLUSTER_NAME:=kcp-cluster-crc}
+: ${SYNC_TARGETS_DIR:=config/deploy/sync-targets}
 CRC_KUBECONFIG="${CRC_CLUSTER_NAME}.kubeconfig"
 PULL_SECRET=~/pull-secret
 KUBECONFIG_KCP_ADMIN=.kcp/admin.kubeconfig
@@ -66,10 +67,16 @@ crc start -p $PULL_SECRET
 cp ~/.crc/machines/crc/kubeconfig ${TEMP_DIR}/${CRC_KUBECONFIG}
 cp ${TEMP_DIR}/${CRC_KUBECONFIG} ${TEMP_DIR}/${CRC_KUBECONFIG}.internal
 
+# Old syncers that might already exist on the crc vm can cause issues, so we make sure everything kcp related is removed.
+echo "Removing existing kcp resources"
+kubectl --context crc-admin get ns | grep kcp | awk '{print $1}' | xargs kubectl --context crc-admin delete ns
+
 echo "Registering crc cluster into KCP"
 KUBECONFIG=${KUBECONFIG_KCP_ADMIN} ./bin/kubectl-kcp ws root:kuadrant
-KUBECONFIG=${KUBECONFIG_KCP_ADMIN} ${KUBECTL_KCP_BIN} workload sync ${CRC_CLUSTER_NAME} --syncer-image=${KCP_SYNCER_IMAGE} --resources=ingresses.networking.k8s.io,services --output-file ${TEMP_DIR}/${CRC_CLUSTER_NAME}-syncer.yaml
-kubectl --context crc-admin apply -f ${TEMP_DIR}/${CRC_CLUSTER_NAME}-syncer.yaml
+KUBECONFIG=${KUBECONFIG_KCP_ADMIN} ${KUBECTL_KCP_BIN} workload sync ${CRC_CLUSTER_NAME} --syncer-image=${KCP_SYNCER_IMAGE} --resources=ingresses.networking.k8s.io,services --output-file ${SYNC_TARGETS_DIR}/${CRC_CLUSTER_NAME}-syncer.yaml
+KUBECONFIG=${KUBECONFIG_KCP_ADMIN} kubectl annotate --overwrite synctarget ${CRC_CLUSTER_NAME} featuregates.experimental.workload.kcp.dev/advancedscheduling='true'
+
+kubectl --context crc-admin apply -f ${SYNC_TARGETS_DIR}/${CRC_CLUSTER_NAME}-syncer.yaml
 
 # TODO: Figure out the right order of cmds, kubeconfig, context & env vars to deploy the observability operator
 # Notes from installing manually on a managed openshift cluster:

--- a/utils/local-setup.sh
+++ b/utils/local-setup.sh
@@ -21,6 +21,7 @@ KCP_GLBC_DIR="${LOCAL_SETUP_DIR}/.."
 source "${LOCAL_SETUP_DIR}"/.setupEnv
 
 DO_BREW="false"
+: ${USE_CRC_CLUSTER:="false"}
 
 usage() { echo "usage: ./local-setup.sh -c <number of clusters> <-b>" 1>&2; exit 1; }
 while getopts ":bc:" arg; do
@@ -185,8 +186,12 @@ KUBECONFIG=${KUBECONFIG_KCP_ADMIN} ${KUBECTL_KCP_BIN} workspace create "kuadrant
 KUBECONFIG=${KUBECONFIG_KCP_ADMIN} ${SCRIPT_DIR}/deploy.sh -k "${KUSTOMIZATION_DIR}" -c "none"
 
 #3. Create GLBC sync target and wait for it to be ready
-createKINDCluster "${KIND_CLUSTER_PREFIX}1" 8081 8444
-kubectl apply -f ${GLBC_DEPLOYMENTS_DIR}/sync-targets/kcp-cluster-1-syncer.yaml
+if [[ "$USE_CRC_CLUSTER" == "true" ]]; then
+  CRC_CLUSTER_NAME=kcp-cluster-1 ${SCRIPT_DIR}/local-setup-add-crc-cluster.sh
+else
+  createKINDCluster "${KIND_CLUSTER_PREFIX}1" 8081 8444
+  kubectl apply -f ${GLBC_DEPLOYMENTS_DIR}/sync-targets/kcp-cluster-1-syncer.yaml
+fi
 
 KUBECONFIG=${KUBECONFIG_KCP_ADMIN} ${KUBECTL_KCP_BIN} workspace use "${GLBC_WORKSPACE}"
 


### PR DESCRIPTION
Adds an option to local-setup to use a CRC cluster to back the default sync target (kcp-cluster-1) instead of kind.

```
make local-setup USE_CRC=true
```
