### PR TITLE
Add smoke test GH action

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -1,0 +1,34 @@
+name: Smoke
+
+on: workflow_dispatch
+
+jobs:
+  smoke:
+    name: Smoke
+    environment: stable
+    runs-on: ubuntu-20.04
+    env:
+      AWS_DNS_PUBLIC_ZONE_ID: ${{ secrets.AWS_DNS_PUBLIC_ZONE_ID }}
+      GLBC_DOMAIN: ${{ secrets.GLBC_DOMAIN }}
+      GLBC_ENABLE_CUSTOM_HOSTS: false
+      GLBC_EXPORT: ${{ secrets.GLBC_EXPORT }}
+      GLBC_WORKSPACE: ${{ secrets.GLBC_WORKSPACE }}
+      TEST_WORKSPACE: ${{ secrets.TEST_WORKSPACE }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: v1.18
+      - name: Setup Kubeconfig
+        run: |
+          kubectl config --kubeconfig=test.kubeconfig set-cluster glbc --server=${{ secrets.TEST_KUBE_HOST }}
+          kubectl config --kubeconfig=test.kubeconfig set-credentials glbc --token=${{ secrets.TEST_KUBE_TOKEN }}
+          kubectl config --kubeconfig=test.kubeconfig set-context system:admin --cluster=glbc --user=glbc
+          kubectl config --kubeconfig=test.kubeconfig use-context system:admin
+          kubectl config --kubeconfig=test.kubeconfig get-contexts
+          export KUBECONFIG="$(pwd)"/test.kubeconfig
+          echo "KUBECONFIG=${KUBECONFIG}" >> $GITHUB_ENV
+      - name: Run smoke tests
+        run: |
+          export KUBECONFIG=${{ env.KUBECONFIG }}
+          make smoke

--- a/test/smoke/basic_ingress.go
+++ b/test/smoke/basic_ingress.go
@@ -20,11 +20,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/rs/xid"
-
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +35,7 @@ import (
 )
 
 func createTestIngress(t Test, namespace *corev1.Namespace, serviceName string) *networkingv1.Ingress {
-	name := "test-" + xid.New().String()
+	name := GenerateName("test-ing-")
 
 	ingress, err := t.Client().Core().Cluster(logicalcluster.From(namespace)).NetworkingV1().Ingresses(namespace.Name).
 		Apply(t.Ctx(), IngressConfiguration(namespace.Name, name, serviceName,"test.glbc.com"), ApplyOptions)

--- a/test/support/namespace.go
+++ b/test/support/namespace.go
@@ -15,17 +15,15 @@ limitations under the License.
 package support
 
 import (
-	"github.com/onsi/gomega"
-	"github.com/rs/xid"
-
 	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func createTestNamespace(t Test, options ...Option) *corev1.Namespace {
-	name := "test-" + xid.New().String()
+	name := GenerateName("test-ns-")
 
 	namespace := &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{

--- a/test/support/support.go
+++ b/test/support/support.go
@@ -15,10 +15,12 @@ limitations under the License.
 package support
 
 import (
+	"fmt"
 	"os"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/kcp-dev/logicalcluster/v2"
 
@@ -35,6 +37,10 @@ const (
 	testWorkspaceName            = "TEST_WORKSPACE"
 	glbcWorkspaceName            = "GLBC_WORKSPACE"
 	glbcExportName               = "GLBC_EXPORT"
+
+	maxNameLength          = 63
+	randomLength           = 5
+	MaxGeneratedNameLength = maxNameLength - randomLength
 )
 
 var (
@@ -51,4 +57,12 @@ func getEnvLogicalClusterName(key string, fallback logicalcluster.Name) logicalc
 		return fallback
 	}
 	return logicalcluster.New(value)
+}
+
+// GenerateName Borrowed from https://github.com/kubernetes/apiserver/blob/v0.25.2/pkg/storage/names/generate.go
+func GenerateName(base string) string {
+	if len(base) > MaxGeneratedNameLength {
+		base = base[:MaxGeneratedNameLength]
+	}
+	return fmt.Sprintf("%s%s", base, utilrand.String(randomLength))
 }

--- a/test/support/workspace.go
+++ b/test/support/workspace.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 
 	"github.com/onsi/gomega"
-	"github.com/rs/xid"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -104,7 +102,7 @@ func WorkspacePhase(workspace *tenancyv1beta1.Workspace) tenancyv1alpha1.Cluster
 }
 
 func createTestWorkspace(t Test) *tenancyv1beta1.Workspace {
-	name := "test-" + xid.New().String()
+	name := GenerateName("test-ws-")
 
 	workspace := &tenancyv1beta1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Closes #444 

## Description of Changes

Adds a GitHub action to run the smoke test against the stable environment.

Update the name generate function used for resources in smoke and performance tests so they are shorter and more meaningful. Uses the same GenerateName function from k8s