### PR TITLE
Update smoke and perf test GH actions

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -1,4 +1,4 @@
-name: Performance
+name: Performance Tests
 
 on:
   workflow_dispatch:
@@ -15,11 +15,16 @@ on:
         description: 'Number of Workspaces to create'
         required: false
         default: '2'
+      environment:
+        description: 'Environment to run tests against'
+        type: environment
+        required: true
 
 jobs:
-  load:
-    name: Load
-    environment: unstable
+  ingress_test:
+    name: Ingress Load Test
+    environment: ${{ inputs.environment || 'unstable' }}
+    concurrency: ${{ inputs.environment || 'unstable' }}
     runs-on: ubuntu-20.04
     env:
       TEST_DNSRECORD_COUNT: ${{ github.event.inputs.test_dnsrecord_count}}
@@ -27,6 +32,11 @@ jobs:
       TEST_WORKSPACE_COUNT: ${{ github.event.inputs.test_workspace_count}}
       AWS_DNS_PUBLIC_ZONE_ID: ${{ secrets.AWS_DNS_PUBLIC_ZONE_ID }}
       GLBC_DOMAIN: ${{ secrets.GLBC_DOMAIN }}
+      GLBC_ENABLE_CUSTOM_HOSTS: ${{ secrets.GLBC_ENABLE_CUSTOM_HOSTS }}
+      GLBC_EXPORT: ${{ secrets.GLBC_EXPORT }}
+      GLBC_WORKSPACE: ${{ secrets.GLBC_WORKSPACE }}
+      TEST_WORKSPACE: ${{ secrets.TEST_WORKSPACE }}
+      TEST_TAGS: performance,ingress
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -34,26 +44,15 @@ jobs:
           go-version: v1.18
       - name: Setup Kubeconfig
         run: |
-          kubectl config --kubeconfig=test.kubeconfig set-cluster glbc --server=${{ secrets.TEST_KUBE_HOST }}
-          kubectl config --kubeconfig=test.kubeconfig set-credentials glbc --token=${{ secrets.TEST_KUBE_TOKEN }}
-          kubectl config --kubeconfig=test.kubeconfig set-context system:admin --cluster=glbc --namespace=${{ secrets.CICD_KUBE_NS }} --user=glbc
-          kubectl config --kubeconfig=test.kubeconfig use-context system:admin
+          make generate-test-oidc-kubeconfig \
+              TEST_OIDC_KUBECONFIG=test.kubeconfig \
+              TEST_KUBE_HOST=${{ secrets.TEST_KUBE_HOST }} \
+              TEST_KUBE_OIDC_ISSUER_URL=${{ secrets.TEST_KUBE_OIDC_ISSUER_URL }} \
+              TEST_KUBE_OIDC_CLIENT_ID=${{ secrets.TEST_KUBE_OIDC_CLIENT_ID }} \
+              TEST_KUBE_OIDC_CLIENT_SECRET=${{ secrets.TEST_KUBE_OIDC_CLIENT_SECRET }}
           kubectl config --kubeconfig=test.kubeconfig get-contexts
           export KUBECONFIG="$(pwd)"/test.kubeconfig
           echo "KUBECONFIG=${KUBECONFIG}" >> $GITHUB_ENV
-      - name: Run pre test
-        env:
-          TEST_DNSRECORD_COUNT: 1
-          TEST_INGRESS_COUNT: 1
-          TEST_WORKSPACE_COUNT: 1
-        run: |
-          export KUBECONFIG=${{ env.KUBECONFIG }}
-          echo "TEST_INGRESS_COUNT = ${{ env.TEST_INGRESS_COUNT }}"
-          echo "TEST_DNSRECORD_COUNT = ${{ env.TEST_DNSRECORD_COUNT }}"
-          echo "TEST_WORKSPACE_COUNT = ${{ env.TEST_WORKSPACE_COUNT }}"
-          echo "AWS_DNS_PUBLIC_ZONE_ID = ${{ env.AWS_DNS_PUBLIC_ZONE_ID }}"
-          echo "GLBC_DOMAIN = ${{ env.GLBC_DOMAIN }}"
-          make performance
       - name: Run performance tests
         run: |
           export KUBECONFIG=${{ env.KUBECONFIG }}
@@ -62,4 +61,46 @@ jobs:
           echo "TEST_WORKSPACE_COUNT = ${{ env.TEST_WORKSPACE_COUNT }}"
           echo "AWS_DNS_PUBLIC_ZONE_ID = ${{ env.AWS_DNS_PUBLIC_ZONE_ID }}"
           echo "GLBC_DOMAIN = ${{ env.GLBC_DOMAIN }}"
-          make performance
+          make performance TEST_TAGS=${{ env.TEST_TAGS }}
+
+  dns_record_test:
+    name: DNSRecord Load Test
+    environment: ${{ inputs.environment || 'unstable' }}
+    concurrency: ${{ inputs.environment || 'unstable' }}
+    runs-on: ubuntu-20.04
+    env:
+      TEST_DNSRECORD_COUNT: ${{ github.event.inputs.test_dnsrecord_count}}
+      TEST_INGRESS_COUNT: ${{ github.event.inputs.test_ingress_count }}
+      TEST_WORKSPACE_COUNT: ${{ github.event.inputs.test_workspace_count}}
+      AWS_DNS_PUBLIC_ZONE_ID: ${{ secrets.AWS_DNS_PUBLIC_ZONE_ID }}
+      GLBC_DOMAIN: ${{ secrets.GLBC_DOMAIN }}
+      GLBC_ENABLE_CUSTOM_HOSTS: ${{ secrets.GLBC_ENABLE_CUSTOM_HOSTS }}
+      GLBC_EXPORT: ${{ secrets.GLBC_EXPORT }}
+      GLBC_WORKSPACE: ${{ secrets.GLBC_WORKSPACE }}
+      TEST_WORKSPACE: ${{ secrets.TEST_WORKSPACE }}
+      TEST_TAGS: performance,dnsrecord
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: v1.18
+      - name: Setup Kubeconfig
+        run: |
+          make generate-test-oidc-kubeconfig \
+              TEST_OIDC_KUBECONFIG=test.kubeconfig \
+              TEST_KUBE_HOST=${{ secrets.TEST_KUBE_HOST }} \
+              TEST_KUBE_OIDC_ISSUER_URL=${{ secrets.TEST_KUBE_OIDC_ISSUER_URL }} \
+              TEST_KUBE_OIDC_CLIENT_ID=${{ secrets.TEST_KUBE_OIDC_CLIENT_ID }} \
+              TEST_KUBE_OIDC_CLIENT_SECRET=${{ secrets.TEST_KUBE_OIDC_CLIENT_SECRET }}
+          kubectl config --kubeconfig=test.kubeconfig get-contexts
+          export KUBECONFIG="$(pwd)"/test.kubeconfig
+          echo "KUBECONFIG=${KUBECONFIG}" >> $GITHUB_ENV
+      - name: Run performance tests
+        run: |
+          export KUBECONFIG=${{ env.KUBECONFIG }}
+          echo "TEST_INGRESS_COUNT = ${{ env.TEST_INGRESS_COUNT }}"
+          echo "TEST_DNSRECORD_COUNT = ${{ env.TEST_DNSRECORD_COUNT }}"
+          echo "TEST_WORKSPACE_COUNT = ${{ env.TEST_WORKSPACE_COUNT }}"
+          echo "AWS_DNS_PUBLIC_ZONE_ID = ${{ env.AWS_DNS_PUBLIC_ZONE_ID }}"
+          echo "GLBC_DOMAIN = ${{ env.GLBC_DOMAIN }}"
+          make performance TEST_TAGS=${{ env.TEST_TAGS }}

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -1,19 +1,30 @@
-name: Smoke
+name: Smoke Tests
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to run tests against'
+        type: environment
+        required: true
+  schedule:
+    # Runs twice a day at 06:13 and 18:13
+    - cron: "13 6,18 * * *"
 
 jobs:
-  smoke:
-    name: Smoke
-    environment: stable
+  ingress_test:
+    name: Ingress Test
+    environment: ${{ inputs.environment || 'unstable' }}
+    concurrency: ${{ inputs.environment || 'unstable' }}
     runs-on: ubuntu-20.04
     env:
       AWS_DNS_PUBLIC_ZONE_ID: ${{ secrets.AWS_DNS_PUBLIC_ZONE_ID }}
       GLBC_DOMAIN: ${{ secrets.GLBC_DOMAIN }}
-      GLBC_ENABLE_CUSTOM_HOSTS: false
+      GLBC_ENABLE_CUSTOM_HOSTS: ${{ secrets.GLBC_ENABLE_CUSTOM_HOSTS }}
       GLBC_EXPORT: ${{ secrets.GLBC_EXPORT }}
       GLBC_WORKSPACE: ${{ secrets.GLBC_WORKSPACE }}
       TEST_WORKSPACE: ${{ secrets.TEST_WORKSPACE }}
+      TEST_TAGS: smoke,ingress
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -21,21 +32,16 @@ jobs:
           go-version: v1.18
       - name: Setup Kubeconfig
         run: |
-          kubectl config --kubeconfig=test.kubeconfig set-cluster kcp --server=${{ secrets.TEST_KUBE_HOST }}
-
-          kubectl config --kubeconfig=test.kubeconfig set-credentials oidc \
-            --auth-provider=oidc \
-            --auth-provider-arg=idp-issuer-url=${{ secrets.TEST_KUBE_OIDC_ISSUER_URL }} \
-            --auth-provider-arg=client-id=${{ secrets.TEST_KUBE_OIDC_CLIENT_ID }} \
-            --auth-provider-arg=refresh-token=${{ secrets.TEST_KUBE_OIDC_CLIENT_SECRET }}
-
-          kubectl config --kubeconfig=test.kubeconfig set-context system:admin --cluster=kcp --user=oidc
-          kubectl config --kubeconfig=test.kubeconfig use-context system:admin
+          make generate-test-oidc-kubeconfig \
+              TEST_OIDC_KUBECONFIG=test.kubeconfig \
+              TEST_KUBE_HOST=${{ secrets.TEST_KUBE_HOST }} \
+              TEST_KUBE_OIDC_ISSUER_URL=${{ secrets.TEST_KUBE_OIDC_ISSUER_URL }} \
+              TEST_KUBE_OIDC_CLIENT_ID=${{ secrets.TEST_KUBE_OIDC_CLIENT_ID }} \
+              TEST_KUBE_OIDC_CLIENT_SECRET=${{ secrets.TEST_KUBE_OIDC_CLIENT_SECRET }}
           kubectl config --kubeconfig=test.kubeconfig get-contexts
-
           export KUBECONFIG="$(pwd)"/test.kubeconfig
           echo "KUBECONFIG=${KUBECONFIG}" >> $GITHUB_ENV
       - name: Run smoke tests
         run: |
           export KUBECONFIG=${{ env.KUBECONFIG }}
-          make smoke
+          make smoke TEST_TAGS=${{ env.TEST_TAGS }}

--- a/test/smoke/ingress_test.go
+++ b/test/smoke/ingress_test.go
@@ -1,4 +1,4 @@
-//go:build smoke
+//go:build smoke && ingress
 
 package smoke
 


### PR DESCRIPTION

## Description of Changes

Add environment as input to smoke and performance test GH Actions allowing them to be executed against any environment configured in GitHub. Also add concurrency to ensure that only one instance of either the smoke or performance tests are running in any environment at any time.

Adds a schedule to the smoke test, currently configured to run twice a day at 06:13 and 18:13, to try and avoid times that would have a high likelihood of failing to due to demand.

Rename smoke test and job name and allow specifying tags on the smoke test build to narrow scope as required. Currently we only have a single ingress test but more could be added later and run as independent jobs in the smoke test run.

Add make target to generate test oidc kubeconfig

```
make generate-test-oidc-kubeconfig
```
