### PR TITLE
Remove from alert the check on the absence of "kcp-unstable-redhat-hcg"

### DIFF
--- a/config/observability/monitoring_resources/openshift/GLBCInstanceDown.dhall
+++ b/config/observability/monitoring_resources/openshift/GLBCInstanceDown.dhall
@@ -17,7 +17,7 @@ in  PrometheusOperator.Rule::{
     , alert = Some "GLBCInstanceDown"
     , expr =
         K8s.IntOrString.String
-          "(absent(kube_pod_labels{label_glbc_name=\"kcp-stable-redhat-hcg\", pod=~\"kcp-glbc-controller-manager.*\"}) or absent(kube_pod_labels{label_glbc_name=\"kcp-stable-redhat-hcg-unstable\", pod=~\"kcp-glbc-controller-manager.*\"}) or absent(kube_pod_labels{label_glbc_name=\"kcp-unstable-redhat-hcg\", pod=~\"kcp-glbc-controller-manager.*\"})) > 0"
+          "(absent(kube_pod_labels{label_glbc_name=\"kcp-stable-redhat-hcg\", pod=~\"kcp-glbc-controller-manager.*\"}) or absent(kube_pod_labels{label_glbc_name=\"kcp-stable-redhat-hcg-unstable\", pod=~\"kcp-glbc-controller-manager.*\"})) > 0"
     , for = Some (Duration.show { amount = 5, unit = TimeUnit.Type.Minutes })
     , labels = Some
         (toMap { severity = AlertSeverity.show AlertSeverity.Type.Critical })

--- a/config/observability/openshift/monitoring_resources/GLBCInstanceDown.yaml
+++ b/config/observability/openshift/monitoring_resources/GLBCInstanceDown.yaml
@@ -4,7 +4,7 @@ annotations:
   description: "One or more GLBC instances are down: {{ $labels.label_glbc_name }} - Either the GLBC component is not running, is misconfigured, or the metrics endpoint is not responding."
   runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/glbctargetdown.adoc
   summary: One or more GLBC instances are down
-expr: "(absent(kube_pod_labels{label_glbc_name=\"kcp-stable-redhat-hcg\", pod=~\"kcp-glbc-controller-manager.*\"}) or absent(kube_pod_labels{label_glbc_name=\"kcp-stable-redhat-hcg-unstable\", pod=~\"kcp-glbc-controller-manager.*\"}) or absent(kube_pod_labels{label_glbc_name=\"kcp-unstable-redhat-hcg\", pod=~\"kcp-glbc-controller-manager.*\"})) > 0"
+expr: "(absent(kube_pod_labels{label_glbc_name=\"kcp-stable-redhat-hcg\", pod=~\"kcp-glbc-controller-manager.*\"}) or absent(kube_pod_labels{label_glbc_name=\"kcp-stable-redhat-hcg-unstable\", pod=~\"kcp-glbc-controller-manager.*\"})) > 0"
 for: "5m"
 labels:
   severity: critical

--- a/config/observability/openshift/monitoring_resources/rules-hcg-prometheusrule.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-hcg-prometheusrule.yaml
@@ -14,7 +14,7 @@ spec:
             description: "One or more GLBC instances are down: {{ $labels.label_glbc_name }} - Either the GLBC component is not running, is misconfigured, or the metrics endpoint is not responding."
             runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/glbctargetdown.adoc
             summary: One or more GLBC instances are down
-          expr: "(absent(kube_pod_labels{label_glbc_name=\"kcp-stable-redhat-hcg\", pod=~\"kcp-glbc-controller-manager.*\"}) or absent(kube_pod_labels{label_glbc_name=\"kcp-stable-redhat-hcg-unstable\", pod=~\"kcp-glbc-controller-manager.*\"}) or absent(kube_pod_labels{label_glbc_name=\"kcp-unstable-redhat-hcg\", pod=~\"kcp-glbc-controller-manager.*\"})) > 0"
+          expr: "(absent(kube_pod_labels{label_glbc_name=\"kcp-stable-redhat-hcg\", pod=~\"kcp-glbc-controller-manager.*\"}) or absent(kube_pod_labels{label_glbc_name=\"kcp-stable-redhat-hcg-unstable\", pod=~\"kcp-glbc-controller-manager.*\"})) > 0"
           for: "5m"
           labels:
             severity: critical

--- a/config/observability/openshift/monitoring_resources/rules-hcg.yaml
+++ b/config/observability/openshift/monitoring_resources/rules-hcg.yaml
@@ -7,7 +7,7 @@ groups:
           description: "One or more GLBC instances are down: {{ $labels.label_glbc_name }} - Either the GLBC component is not running, is misconfigured, or the metrics endpoint is not responding."
           runbook_url: https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/glbctargetdown.adoc
           summary: One or more GLBC instances are down
-        expr: "(absent(kube_pod_labels{label_glbc_name=\"kcp-stable-redhat-hcg\", pod=~\"kcp-glbc-controller-manager.*\"}) or absent(kube_pod_labels{label_glbc_name=\"kcp-stable-redhat-hcg-unstable\", pod=~\"kcp-glbc-controller-manager.*\"}) or absent(kube_pod_labels{label_glbc_name=\"kcp-unstable-redhat-hcg\", pod=~\"kcp-glbc-controller-manager.*\"})) > 0"
+        expr: "(absent(kube_pod_labels{label_glbc_name=\"kcp-stable-redhat-hcg\", pod=~\"kcp-glbc-controller-manager.*\"}) or absent(kube_pod_labels{label_glbc_name=\"kcp-stable-redhat-hcg-unstable\", pod=~\"kcp-glbc-controller-manager.*\"})) > 0"
         for: "5m"
         labels:
           severity: critical

--- a/config/observability/openshift/monitoring_resources/rules_unit_tests/GLBCInstanceDown_test.yaml
+++ b/config/observability/openshift/monitoring_resources/rules_unit_tests/GLBCInstanceDown_test.yaml
@@ -11,8 +11,6 @@ tests:
         values: "1+0x5 stale"
       - series: kube_pod_labels{label_glbc_name="kcp-stable-redhat-hcg-unstable", pod="kcp-glbc-controller-manager"}
         values: "1+0x20"
-      - series: kube_pod_labels{label_glbc_name="kcp-unstable-redhat-hcg", pod="kcp-glbc-controller-manager"}
-        values: "1+0x20"
     alert_rule_test:
       - eval_time: 5m
         alertname: GLBCInstanceDown
@@ -35,8 +33,6 @@ tests:
         values: "1+0x5 stale"
       - series: kube_pod_labels{label_glbc_name="kcp-stable-redhat-hcg-unstable", pod="kcp-glbc-controller-manager"}
         values: "1+0x20"
-      - series: kube_pod_labels{label_glbc_name="kcp-unstable-redhat-hcg", pod="kcp-glbc-controller-manager"}
-        values: "1+0x5 stale"
     alert_rule_test:
       - eval_time: 5m
         alertname: GLBCInstanceDown
@@ -51,13 +47,6 @@ tests:
               summary: 'One or more GLBC instances are down'
               description: 'One or more GLBC instances are down: kcp-stable-redhat-hcg - Either the GLBC component is not running, is misconfigured, or the metrics endpoint is not responding.'
               runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/glbctargetdown.adoc'
-          - exp_labels:
-              severity: critical
-              label_glbc_name: kcp-unstable-redhat-hcg
-            exp_annotations:
-              summary: 'One or more GLBC instances are down'
-              description: 'One or more GLBC instances are down: kcp-unstable-redhat-hcg - Either the GLBC component is not running, is misconfigured, or the metrics endpoint is not responding.'
-              runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/glbctargetdown.adoc'
 
 #  Testing when all glbc instances are down
   - interval: 1m
@@ -65,8 +54,6 @@ tests:
       - series: kube_pod_labels{label_glbc_name="kcp-stable-redhat-hcg", pod="kcp-glbc-controller-manager"}
         values: "1+0x5 stale"
       - series: kube_pod_labels{label_glbc_name="kcp-stable-redhat-hcg-unstable", pod="kcp-glbc-controller-manager"}
-        values: "1+0x5 stale"
-      - series: kube_pod_labels{label_glbc_name="kcp-unstable-redhat-hcg", pod="kcp-glbc-controller-manager"}
         values: "1+0x5 stale"
     alert_rule_test:
       - eval_time: 5m
@@ -88,11 +75,4 @@ tests:
             exp_annotations:
               summary: 'One or more GLBC instances are down'
               description: 'One or more GLBC instances are down: kcp-stable-redhat-hcg-unstable - Either the GLBC component is not running, is misconfigured, or the metrics endpoint is not responding.'
-              runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/glbctargetdown.adoc'
-          - exp_labels:
-              severity: critical
-              label_glbc_name: kcp-unstable-redhat-hcg
-            exp_annotations:
-              summary: 'One or more GLBC instances are down'
-              description: 'One or more GLBC instances are down: kcp-unstable-redhat-hcg - Either the GLBC component is not running, is misconfigured, or the metrics endpoint is not responding.'
               runbook_url: 'https://github.com/Kuadrant/kcp-glbc/blob/main/docs/observability/runbooks/glbctargetdown.adoc'


### PR DESCRIPTION
## Description of Changes
- Removed from alert and unit test the check for the label_glbc_name = "kcp-unstable-redhat-hcg", to stop the alert from firing unnecessarily.