### PR TITLE
Fix cleanup of kcp resources on fresh crc cluster

### DIFF
--- a/utils/local-setup-add-crc-cluster.sh
+++ b/utils/local-setup-add-crc-cluster.sh
@@ -74,7 +74,7 @@ cp ${TEMP_DIR}/${CRC_KUBECONFIG} ${TEMP_DIR}/${CRC_KUBECONFIG}.internal
 
 # Old syncers that might already exist on the crc vm can cause issues, so we make sure everything kcp related is removed.
 echo "Removing existing kcp resources"
-kubectl --context crc-admin get ns | grep kcp | awk '{print $1}' | xargs kubectl --context crc-admin delete ns
+kubectl --context crc-admin get ns | grep kcp | awk '{print $1}' | xargs -r kubectl --context crc-admin delete ns
 
 echo "Registering crc cluster into KCP"
 KUBECONFIG=${KUBECONFIG_KCP_ADMIN} ./bin/kubectl-kcp ws root:kuadrant

--- a/utils/local-setup.sh
+++ b/utils/local-setup.sh
@@ -19,7 +19,7 @@
 LOCAL_SETUP_DIR="$(dirname "${BASH_SOURCE[0]}")"
 KCP_GLBC_DIR="${LOCAL_SETUP_DIR}/.."
 #run KCP on port 6444 to prevent collisions with CRC
-KCP_SECURE_PORT="6444"
+: ${KCP_SECURE_PORT:="6444"}
 source "${LOCAL_SETUP_DIR}"/.setupEnv
 
 DO_BREW="false"


### PR DESCRIPTION
## Description of Changes

Add -r (--no-run-if-empty) flag to xargs command to ensure it doesn't run if no kcp namespaces are found.

## Verification

* Delete any existing crc cluster `crc  delete`
* Run setup using crc `make local-setup USE_CRC=true`
