### PR TITLE
Hash Domain Verification Token value + Unit Test

### DIFF
--- a/pkg/_internal/util/math/hash.go
+++ b/pkg/_internal/util/math/hash.go
@@ -1,0 +1,19 @@
+package math
+
+import (
+	"crypto/sha256"
+	"math/big"
+)
+
+// HashString function can be used to hash a string
+func HashString(aString string) string {
+	hash := sha256.Sum224([]byte(aString))
+	base62hash := toBase62(hash)
+	return base62hash
+}
+
+func toBase62(hash [28]byte) string {
+	var i big.Int
+	i.SetBytes(hash[:])
+	return i.Text(62)
+}

--- a/pkg/_internal/util/math/hash_test.go
+++ b/pkg/_internal/util/math/hash_test.go
@@ -1,0 +1,16 @@
+package math_test
+
+import (
+	"github.com/kuadrant/kcp-glbc/pkg/_internal/util/math"
+	"testing"
+)
+
+func TestHashString(t *testing.T) {
+
+	someString := "kcp-glbc-24933749"
+	someString = math.HashString(someString)
+
+	if someString != "agrS4f0o5gUNZkFTEZSWTCh5P14EfAfkBuzOBI" {
+		t.Errorf("Unexpected hashed string value, expected agrS4f0o5gUNZkFTEZSWTCh5P14EfAfkBuzOBI, got %s", someString)
+	}
+}

--- a/pkg/apis/kuadrant/v1/types.go
+++ b/pkg/apis/kuadrant/v1/types.go
@@ -6,6 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/kuadrant/kcp-glbc/pkg/_internal/util/math"
 )
 
 // +crd
@@ -25,7 +26,7 @@ type DomainVerification struct {
 }
 
 func (in *DomainVerification) GetToken() string {
-	return fmt.Sprintf("glbctoken=glbc-%s", logicalcluster.From(in))
+	return fmt.Sprint(math.HashString(logicalcluster.From(in).String()))
 }
 
 type DomainVerificationSpec struct {

--- a/pkg/apis/kuadrant/v1/types_test.go
+++ b/pkg/apis/kuadrant/v1/types_test.go
@@ -1,0 +1,36 @@
+package v1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestGetToken(t *testing.T) {
+	tests := []struct {
+		testName string
+		obj      DomainVerification
+		verify   func(obj DomainVerification, t *testing.T)
+	}{
+		{
+			testName: "returns hashed token",
+			obj: DomainVerification{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					"kcp.dev/cluster": "kcp-glbc",
+				}},
+			},
+			verify: func(obj DomainVerification, t *testing.T) {
+
+				expectedToken := "7K2kvu2bO7fC331UKtz4EEM2KdaLldG0wLHwKt"
+
+				if obj.GetToken() != expectedToken {
+					t.Errorf("expected Token '%s' to match expectedToken: '%s'", obj.GetToken(), expectedToken)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			tt.verify(tt.obj, t)
+		})
+	}
+}

--- a/pkg/dns/verification_test.go
+++ b/pkg/dns/verification_test.go
@@ -18,7 +18,7 @@ func (mr *mockResolver) LookupTXT(ctx context.Context, domain string) ([]string,
 }
 
 func TestTxtRecordExists(t *testing.T) {
-	expectedRecordValue := "glbctoken=glbc-root:default:kcp-glbc"
+	expectedRecordValue := "bEwDwoiX4Y4VpLPgzUbZ0WKSKqjWaZ8EIMtMs3"
 	cases := []struct {
 		Name        string
 		ExpectErr   bool


### PR DESCRIPTION
Closes #447 


## Description of Changes
- Added two functions containing an algorithm to hash the domain verification token. I moved these hashing functions to the util directory as this function is a generic one which will hash any given string. + added unit test for hash function.

- Updated the GetToken() function to return a hashed value of the domain verification token. + added unit test.

- Updated tests to not expect a workspace value.