### PR TITLE
Update dead links, typo fixes, and formatting fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To get started with the GLBC, we recommend you follow our [Getting Started tutor
 
 ## Development
 
-###Interacting directly with WorkloadClusters
+### Interacting directly with WorkloadClusters
 
 Prefix `kubectl` with the appropriate kubeconfig file from the tmp directory.
 For example:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,13 +5,13 @@ This requires you to have access to a KCP instance to deploy GLBC to, if you wan
 
 **Prerequisite**
 
-* KCP version 0.7
+* KCP version 0.9
 
 **Useful Links**
 
 * [KCP](https://github.com/kcp-dev/kcp)
 * [KCP Docs](https://github.com/kcp-dev/kcp/blob/main/docs)
-* [KCP Locations and Scheduling](https://github.com/kcp-dev/kcp/blob/main/docs/locations-and-scheduling.md#locations-and-scheduling)
+* [KCP Locations and Scheduling](https://github.com/kcp-dev/kcp/blob/main/docs/content/en/main/concepts/locations-and-scheduling.md)
 
 ## GLBC
 
@@ -24,7 +24,7 @@ N.B. You must be targeting a KCP instance in order to install GLBC.
 
 ## GLBC Sync Target
 
-The deployment script will create a `glbc` sync target in the target workspace, however, for GLBC and it's dependencies to deploy the [`KCP syncer`](https://github.com/kcp-dev/kcp/blob/main/docs/syncer.md) resources must be applied to a physical cluster.
+The deployment script will create a `glbc` sync target in the target workspace, however, for GLBC and it's dependencies to deploy the [`KCP syncer`](https://github.com/kcp-dev/kcp/blob/main/docs/content/en/main/concepts/syncer.md) resources must be applied to a physical cluster.
 The exact command will be output as part of the deploy script, but will look something like:
 
 ```

--- a/docs/getting_started/overview.md
+++ b/docs/getting_started/overview.md
@@ -2,9 +2,9 @@
 
 `kcp` is a prototype of a multi-tenant Kubernetes control plane for workloads on many clusters. `kcp` can be used to manage Kubernetes-like applications across one or more clusters and integrate them with cloud services. 
 
-It provides a generic CRD apiserver that is divided into multiple logical clusters (in which each of the logical clusters are fully isolated) that enable multitenancy of cluster-scoped resources such as CRDs and Namespaces. 
+It provides a generic CRD apiserver that is divided into multiple logical clusters (in which each of the logical clusters are fully isolated) that enable multi-tenancy of cluster-scoped resources such as CRDs and Namespaces. 
 
-See the [`kcp` docs](https://github.com/Kuadrant/kcp) for further explanation and to learn more about the terminology, refer to the [docs](https://github.com/kcp-dev/kcp/blob/main/docs/terminology.md).
+See the [`kcp` docs](https://github.com/Kuadrant/kcp) for further explanation and to learn more about the terminology, refer to the [docs](https://github.com/kcp-dev/kcp/blob/e798d372575e694db66bff61bd46700b413e1b9e/docs/content/en/main/concepts/concepts.md).
 
 
 # What is GLBC?

--- a/docs/observability/runbooks/glbctargetdown.adoc
+++ b/docs/observability/runbooks/glbctargetdown.adoc
@@ -35,7 +35,7 @@ kubectl logs deployment/kcp-glbc-controller-manager
 kubectl get events
 ----
 . Based on logs or events you may need to kill the pod to get it into a good state again, or troubleshoot any errors (GLBC or K8S).
-. If GBLC is running OK, check for metrics configuration issues.
+. If GLBC is running OK, check for metrics configuration issues.
 +
 [source,sh]
 ----


### PR DESCRIPTION
Closes #479 


## Description of Changes
- Some formatting fix in our Readme doc. It wasn't showing the text as a sub-title.
- Typos: GBLC to GLBC
- Some dead links to `kcp` docs found and updated.