### PR TITLE
gh-412 move generated host annotation got dns record

### DIFF
--- a/config/crd/bases/kuadrant.dev_dnsrecords.yaml
+++ b/config/crd/bases/kuadrant.dev_dnsrecords.yaml
@@ -82,8 +82,6 @@ spec:
                   type: object
                 minItems: 1
                 type: array
-            required:
-            - endpoints
             type: object
           status:
             description: status is the most recently observed status of the dnsRecord.

--- a/config/kcp-contrib/apiresourceschema.yaml
+++ b/config/kcp-contrib/apiresourceschema.yaml
@@ -80,8 +80,6 @@ spec:
                 type: object
               minItems: 1
               type: array
-          required:
-          - endpoints
           type: object
         status:
           description: status is the most recently observed status of the dnsRecord.

--- a/pkg/apis/kuadrant/v1/types.go
+++ b/pkg/apis/kuadrant/v1/types.go
@@ -125,9 +125,8 @@ type Endpoint struct {
 
 // DNSRecordSpec contains the details of a DNS record.
 type DNSRecordSpec struct {
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems=1
-	// +required
+	// +optional
 	Endpoints []*Endpoint `json:"endpoints"`
 }
 

--- a/pkg/dns/aws/dns.go
+++ b/pkg/dns/aws/dns.go
@@ -174,6 +174,9 @@ func (p *Provider) updateRecord(record *v1.DNSRecord, zoneID, action string) err
 		}
 	}
 
+	if len(changes) == 0 {
+		return nil
+	}
 	input.ChangeBatch = &route53.ChangeBatch{
 		Changes: changes,
 	}

--- a/pkg/reconciler/route/route_reconciler.go
+++ b/pkg/reconciler/route/route_reconciler.go
@@ -24,9 +24,20 @@ func (c *Controller) reconcile(ctx context.Context, route *traffic.Route) error 
 	workload.Migrate(route, c.Queue, c.Logger)
 
 	reconcilers := []traffic.Reconciler{
-		//hostReconciler is first as the others depends on it for the host to be set on the route
+		// DnsReconciler is first as it will set generatedHost field on the traffic object based on the DNSRecord it creates for each route
+		&traffic.DnsReconciler{
+			DeleteDNS:        c.deleteDNS,
+			DNSLookup:        c.hostResolver.LookupIPAddr,
+			GetDNS:           c.getDNS,
+			CreateDNS:        c.createDNS,
+			UpdateDNS:        c.updateDNS,
+			WatchHost:        c.hostsWatcher.StartWatching,
+			ForgetHost:       c.hostsWatcher.StopWatching,
+			ListHostWatchers: c.hostsWatcher.ListHostRecordWatchers,
+			ManagedDomain:    c.domain,
+			Log:              c.Logger,
+		},
 		&traffic.HostReconciler{
-			ManagedDomain:          c.domain,
 			Log:                    c.Logger,
 			GetDomainVerifications: c.getDomainVerifications,
 			CreateOrUpdateTraffic:  c.createOrUpdateRoute,
@@ -42,17 +53,6 @@ func (c *Controller) reconcile(ctx context.Context, route *traffic.Route) error 
 			CopySecret:           c.copySecret,
 			DeleteSecret:         c.deleteTLSSecret,
 			GetSecret:            c.getSecret,
-		},
-		&traffic.DnsReconciler{
-			DeleteDNS:        c.deleteDNS,
-			DNSLookup:        c.hostResolver.LookupIPAddr,
-			GetDNS:           c.getDNS,
-			CreateDNS:        c.createDNS,
-			UpdateDNS:        c.updateDNS,
-			WatchHost:        c.hostsWatcher.StartWatching,
-			ForgetHost:       c.hostsWatcher.StopWatching,
-			ListHostWatchers: c.hostsWatcher.ListHostRecordWatchers,
-			Log:              c.Logger,
 		},
 	}
 	var errs []error

--- a/pkg/traffic/errors.go
+++ b/pkg/traffic/errors.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	ErrInvalidAccessObject  = fmt.Errorf("not a valid traffic object type (expected: ingress or route)")
-	ErrGeneratedHostMissing = fmt.Errorf("generated host annotation '%v' was expected but was not present", ANNOTATION_HCG_HOST)
+	ErrGeneratedHostMissing = fmt.Errorf("generated host annotation was expected but was not set. Ensure DNSRecord created")
 )
 
 func IsInvalidAccessObjectError(err error) bool {

--- a/pkg/traffic/host.go
+++ b/pkg/traffic/host.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/rs/xid"
-
-	"github.com/kuadrant/kcp-glbc/pkg/_internal/metadata"
 	v1 "github.com/kuadrant/kcp-glbc/pkg/apis/kuadrant/v1"
 )
 
@@ -24,14 +21,6 @@ func (r *HostReconciler) GetName() string {
 }
 
 func (r *HostReconciler) Reconcile(ctx context.Context, accessor Interface) (ReconcileStatus, error) {
-	if !metadata.HasAnnotation(accessor, ANNOTATION_HCG_HOST) {
-		// Let's assign it a global hostname if any
-		generatedHost := fmt.Sprintf("%s.%s", xid.New(), r.ManagedDomain)
-		metadata.AddAnnotation(accessor, ANNOTATION_HCG_HOST, generatedHost)
-		//we need this host set and saved on the accessor before we go any further so force an update
-		// if this is not saved we end up with a new host and the certificate can have the wrong host
-		return ReconcileStatusStop, nil
-	}
 	dvs, err := r.GetDomainVerifications(ctx, accessor)
 	if err != nil {
 		return ReconcileStatusContinue, fmt.Errorf("error getting domain verifications: %v", err)

--- a/pkg/traffic/traffic.go
+++ b/pkg/traffic/traffic.go
@@ -51,7 +51,9 @@ type Interface interface {
 	metav1.Object
 	GetKind() string
 	GetHosts() []string
+	GetHCGHost() string
 	SetDNSLBHost(string)
+	SetHCGHost(string)
 	Transform(previous Interface) error
 	GetDNSTargets(ctx context.Context, dnsLookup dnsLookupFunc) (map[logicalcluster.Name]map[string]dns.Target, error)
 	GetLogicalCluster() logicalcluster.Name

--- a/test/support/ingress.go
+++ b/test/support/ingress.go
@@ -191,10 +191,10 @@ func HostsEqualsToGeneratedHost(ingress *traffic.Ingress) bool {
 	return equals
 }
 
-func LBHostEqualToGeneratedHost(ingress *traffic.Ingress) bool {
+func LBHostEqualToGeneratedHost(ingress *traffic.Ingress, record *kuadrantv1.DNSRecord) bool {
 	equals := true
 	for _, i := range ingress.Status.LoadBalancer.Ingress {
-		if i.Hostname != Annotations(ingress)[traffic.ANNOTATION_HCG_HOST] {
+		if i.Hostname != Annotations(record)[traffic.ANNOTATION_HCG_HOST] {
 			equals = false
 		}
 	}


### PR DESCRIPTION
Closes #412 


## Description of Changes
* Moving generated hos annotation to the DNSrecord CR so the user won't have the option to mess with it in the future


## Release and Testing
* e2e tests on the PR should prove the functionality of the change. 
*  check custom domains are working as expected. 
