### PR TITLE
GH-420: Maximal permission policy for DomainVerification 🍃

### DIFF
--- a/config/apiexports/apiexport/glbc-apiexport.yaml
+++ b/config/apiexports/apiexport/glbc-apiexport.yaml
@@ -7,6 +7,8 @@ spec:
   latestResourceSchemas:
   - latest.dnsrecords.kuadrant.dev
   - latest.domainverifications.kuadrant.dev
+  maximalPermissionPolicy:
+    local: {}
   permissionClaims:
   - group: ""
     resource: secrets

--- a/config/rbac/cluster_role.yaml
+++ b/config/rbac/cluster_role.yaml
@@ -20,3 +20,35 @@ rules:
       - create
       - update
       - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: domainverifications:admin:maximal-permission-policy
+rules:
+  - apiGroups:
+    - kuadrant.dev
+    resources:
+      - domainverifications
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+      - watch
+      - get  
+      - list  
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: domainverifications:authenticated:maximal-permission-policy
+rules:
+  - apiGroups:
+    - kuadrant.dev
+    resources:
+      - domainverifications
+    verbs:
+      - watch
+      - get  
+      - list  

--- a/config/rbac/cluster_role_binding.yaml
+++ b/config/rbac/cluster_role_binding.yaml
@@ -9,3 +9,29 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kcp-glbc-controller-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: domainverifications:admin:maximal-permission-policy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: domainverifications:admin:maximal-permission-policy
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io 
+    name: apis.kcp.dev:binding:system:kcp:admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: domainverifications:authenticated:maximal-permission-policy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: domainverifications:authenticated:maximal-permission-policy
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io 
+    name: apis.kcp.dev:binding:system:authenticated


### PR DESCRIPTION
Closes #420 


## Description of Changes

Leverage KCP Maximal Permission Policy to ensure non-admin users do not have permissions to edit the DomainVerification resource. Include ClusterRoles and ClusterRoleBindings that will define the set of permissions of users and admins against the DomainVerification resources


## Release and Testing

* In progress... 🚧

