### PR TITLE
add fix for existing ingresses that have existing specs

### DIFF
--- a/pkg/reconciler/ingress/ingress_reconciler.go
+++ b/pkg/reconciler/ingress/ingress_reconciler.go
@@ -28,7 +28,6 @@ func (c *Controller) reconcile(ctx context.Context, ingress traffic.Interface) e
 		&traffic.HostReconciler{
 			ManagedDomain:          c.domain,
 			Log:                    c.Logger,
-			KuadrantClient:         c.kuadrantClient,
 			GetDomainVerifications: c.getDomainVerifications,
 			CreateOrUpdateTraffic:  c.createOrUpdateIngress,
 			DeleteTraffic:          c.deleteRoute,

--- a/pkg/reconciler/route/route_reconciler.go
+++ b/pkg/reconciler/route/route_reconciler.go
@@ -28,7 +28,6 @@ func (c *Controller) reconcile(ctx context.Context, route *traffic.Route) error 
 		&traffic.HostReconciler{
 			ManagedDomain:          c.domain,
 			Log:                    c.Logger,
-			KuadrantClient:         c.kuadrantClient,
 			GetDomainVerifications: c.getDomainVerifications,
 			CreateOrUpdateTraffic:  c.createOrUpdateRoute,
 			DeleteTraffic:          c.deleteRoute,

--- a/pkg/traffic/host.go
+++ b/pkg/traffic/host.go
@@ -9,13 +9,11 @@ import (
 
 	"github.com/kuadrant/kcp-glbc/pkg/_internal/metadata"
 	v1 "github.com/kuadrant/kcp-glbc/pkg/apis/kuadrant/v1"
-	kuadrantclientv1 "github.com/kuadrant/kcp-glbc/pkg/client/kuadrant/clientset/versioned"
 )
 
 type HostReconciler struct {
 	ManagedDomain          string
 	Log                    logr.Logger
-	KuadrantClient         kuadrantclientv1.ClusterInterface
 	GetDomainVerifications func(ctx context.Context, accessor Interface) (*v1.DomainVerificationList, error)
 	CreateOrUpdateTraffic  CreateOrUpdateTraffic
 	DeleteTraffic          DeleteTraffic
@@ -34,8 +32,6 @@ func (r *HostReconciler) Reconcile(ctx context.Context, accessor Interface) (Rec
 		// if this is not saved we end up with a new host and the certificate can have the wrong host
 		return ReconcileStatusStop, nil
 	}
-	//TODO this should only be set once everything is ready (DNS, and Certificate)
-	//https://github.com/kcp-dev/kcp-glbc/issues/399
 	dvs, err := r.GetDomainVerifications(ctx, accessor)
 	if err != nil {
 		return ReconcileStatusContinue, fmt.Errorf("error getting domain verifications: %v", err)

--- a/pkg/traffic/ingress.go
+++ b/pkg/traffic/ingress.go
@@ -251,7 +251,7 @@ func (a *Ingress) ProcessCustomHosts(_ context.Context, dvs *v1.DomainVerificati
 		for _, uh := range unverifiedRules {
 			replacedHosts = append(replacedHosts, uh.Host)
 		}
-		metadata.AddAnnotation(a, ANNOTATION_HCG_CUSTOM_HOST_REPLACED, fmt.Sprintf(" replaced custom hosts as they are not verfified %v", replacedHosts))
+		metadata.AddAnnotation(a, ANNOTATION_HCG_CUSTOM_HOST_REPLACED, fmt.Sprintf("%v", replacedHosts))
 	} else {
 		metadata.RemoveLabel(a, LABEL_HAS_PENDING_HOSTS)
 		metadata.RemoveAnnotation(a, ANNOTATION_HCG_CUSTOM_HOST_REPLACED)

--- a/pkg/traffic/ingress.go
+++ b/pkg/traffic/ingress.go
@@ -227,7 +227,6 @@ func (a *Ingress) ProcessCustomHosts(_ context.Context, dvs *v1.DomainVerificati
 	for _, rule := range a.Spec.Rules {
 		//ignore any rules for generated unverifiedHosts (these are recalculated later)
 		if rule.Host == generatedHost {
-			verifiedRules = append(verifiedRules, rule)
 			continue
 		}
 
@@ -280,20 +279,10 @@ func (a *Ingress) ProcessCustomHosts(_ context.Context, dvs *v1.DomainVerificati
 				}
 			}
 			for _, pendingRule := range pending.Rules {
+				//recalculate the generatedhost rule in the spec
 				generatedHostRule := *pendingRule.DeepCopy()
 				generatedHostRule.Host = generatedHost
-				foundGeneratedRule := false
-				// if the rule already exists continue on
-				for _, rule := range a.Spec.Rules {
-					if equality.Semantic.DeepEqual(rule, generatedHostRule) {
-						foundGeneratedRule = true
-						break
-					}
-				}
-				//not already present so add the generatedhost rule in the spec
-				if !foundGeneratedRule {
-					a.Spec.Rules = append(a.Spec.Rules, generatedHostRule)
-				}
+				a.Spec.Rules = append(a.Spec.Rules, generatedHostRule)
 
 				//check against domainverification status
 				if IsDomainVerified(pendingRule.Host, dvs.Items) || pendingRule.Host == "" {

--- a/pkg/traffic/traffic.go
+++ b/pkg/traffic/traffic.go
@@ -64,6 +64,10 @@ type Interface interface {
 	TMCEnabed() bool
 }
 
+type DNSService interface {
+	DNSHost(traffic Interface) (string, error)
+}
+
 func tmcEnabled(obj metav1.Object) bool {
 	has, _ := metadata.HasAnnotationsContaining(obj, workload.InternalClusterStatusAnnotationPrefix)
 	return has

--- a/pkg/traffic/traffic.go
+++ b/pkg/traffic/traffic.go
@@ -64,10 +64,6 @@ type Interface interface {
 	TMCEnabed() bool
 }
 
-type DNSService interface {
-	DNSHost(traffic Interface) (string, error)
-}
-
 func tmcEnabled(obj metav1.Object) bool {
 	has, _ := metadata.HasAnnotationsContaining(obj, workload.InternalClusterStatusAnnotationPrefix)
 	return has

--- a/pkg/traffic/traffic.go
+++ b/pkg/traffic/traffic.go
@@ -105,18 +105,20 @@ func IsDomainVerified(host string, dvs []v1.DomainVerification) bool {
 }
 
 func applyTransformPatches(patches []patch, object Interface) error {
-	d, err := json.Marshal(patches)
-	if err != nil {
-		return fmt.Errorf("failed to marshal ingress transform patch %s", err)
-	}
 	// reset spec diffs
 	_, existingDiffs := metadata.HasAnnotationsContaining(object, workload.ClusterSpecDiffAnnotationPrefix)
 	for ek := range existingDiffs {
 		metadata.RemoveAnnotation(object, ek)
 	}
-	// and spec diff for any sync target
-	for _, c := range object.GetSyncTargets() {
-		metadata.AddAnnotation(object, workload.ClusterSpecDiffAnnotationPrefix+c, string(d))
+	if len(patches) != 0 {
+		d, err := json.Marshal(patches)
+		if err != nil {
+			return fmt.Errorf("failed to marshal ingress transform patch %s", err)
+		}
+		// and spec diff for any sync target
+		for _, c := range object.GetSyncTargets() {
+			metadata.AddAnnotation(object, workload.ClusterSpecDiffAnnotationPrefix+c, string(d))
+		}
 	}
 
 	return nil

--- a/test/e2e/ingress_test.go
+++ b/test/e2e/ingress_test.go
@@ -219,7 +219,7 @@ func TestIngress(t *testing.T) {
 	// Test that our transforms have the expected spec and that our status is set to the generated host
 	test.Eventually(Ingress(test, namespace, name)).WithTimeout(TestTimeoutShort).Should(And(
 		Satisfy(OriginalSpecUnchanged(test, &originalIngress.Spec)),
-		Satisfy(TransformedSpec(test, GetDefaultSpec(glbcHost, secretName, name))),
+		Satisfy(TransformedSpec(test, GetDefaultSpec(glbcHost, secretName, name), true, true)),
 		//check that we have a LB set to our generated host
 		WithTransform(LoadBalancerIngresses, HaveLen(1)),
 		Satisfy(LBHostEqualToGeneratedHost),
@@ -251,7 +251,7 @@ func TestIngress(t *testing.T) {
 	// see custom host is not active in ingress
 	test.Eventually(Ingress(test, namespace, name)).WithTimeout(TestTimeoutMedium).Should(And(
 		Satisfy(OriginalSpecUnchanged(test, &originalIngress.Spec)),
-		Satisfy(TransformedSpec(test, GetDefaultSpec(glbcHost, secretName, name))),
+		Satisfy(TransformedSpec(test, GetDefaultSpec(glbcHost, secretName, name), true, true)),
 	))
 	test.T().Log("domain not verified custom host not propigated to cluster")
 
@@ -279,7 +279,7 @@ func TestIngress(t *testing.T) {
 
 	// now we have built up our expected transformed spec check it is the same as the transformations applied to the annotations
 	test.Eventually(Ingress(test, namespace, name)).WithTimeout(TestTimeoutShort).Should(And(
-		Satisfy(TransformedSpec(test, withCustomDomain)),
+		Satisfy(TransformedSpec(test, withCustomDomain, true, true)),
 	))
 
 	test.T().Log("ingress is transformed correctly and in final state")

--- a/test/smoke/basic_ingress.go
+++ b/test/smoke/basic_ingress.go
@@ -164,7 +164,7 @@ func TestIngressBasic(t Test, ingressCount int, zoneID, glbcDomain string) {
 			)),
 			WithTransform(LoadBalancerIngresses, HaveLen(1)),
 			//No custom hosts approved so only expect our default spec in the transform
-			Satisfy(TransformedSpec(t, GetDefaultSpec(generatedHost, tlsSecretName, name))),
+			Satisfy(TransformedSpec(t, GetDefaultSpec(generatedHost, tlsSecretName, name), true, true)),
 			Satisfy(LBHostEqualToGeneratedHost),
 		))
 	}

--- a/test/support/ingress.go
+++ b/test/support/ingress.go
@@ -74,7 +74,7 @@ func IngressEndpoints(t Test, ingress *traffic.Ingress, res dns.HostResolver) []
 
 }
 
-func ValidateTransformedIngress(expectedSpec networkingv1.IngressSpec, transformed *traffic.Ingress) error {
+func ValidateTransformedIngress(expectedSpec networkingv1.IngressSpec, transformed *traffic.Ingress, expectRulesPatch, expectTLSPatch bool) error {
 	st := transformed.GetSyncTargets()
 	for _, target := range st {
 		// ensure each target has a transform value set and it is correct
@@ -123,10 +123,10 @@ func ValidateTransformedIngress(expectedSpec networkingv1.IngressSpec, transform
 				}
 			}
 		}
-		if !rulesPatch {
+		if !rulesPatch && expectRulesPatch {
 			return fmt.Errorf("expected to find a rules patch but one was missing")
 		}
-		if !tlsPatch {
+		if !tlsPatch && expectTLSPatch {
 			return fmt.Errorf("expected to find a tls patch but one was missing")
 		}
 
@@ -135,10 +135,10 @@ func ValidateTransformedIngress(expectedSpec networkingv1.IngressSpec, transform
 }
 
 // TransformedSpec will look at the transforms applied and compare them to the expected spec. cbrookes TODO(look at whether we could take the ingress apply configuration)
-func TransformedSpec(test Test, expectedSpec networkingv1.IngressSpec) func(ingress *traffic.Ingress) bool {
+func TransformedSpec(test Test, expectedSpec networkingv1.IngressSpec, expectRulesDiff, expectTLSDiff bool) func(ingress *traffic.Ingress) bool {
 	test.T().Log("Validating transformed spec for ingress")
 	return func(ingress *traffic.Ingress) bool {
-		if err := ValidateTransformedIngress(expectedSpec, ingress); err != nil {
+		if err := ValidateTransformedIngress(expectedSpec, ingress, expectRulesDiff, expectTLSDiff); err != nil {
 			test.T().Log("transformed spec is not valid", err)
 			return false
 


### PR DESCRIPTION
Closes #


## Description of Changes
ensures that if an ingress has a spec with a glbc generated host that matches the generated host for that ingress, that it is left in the spec


## Remaining Work 
I am looking at adding unit tests as we don't have any coverage of this method currently

The following changes still need to be completed:

- [ ] List any outstanding work here


## Release and Testing
<!-- How should the reviewer test this PR? Write out any special testing steps here. Remove if not needed -->
*


## Dependencies
<!-- If this PR relies on other work or if it should be merged after a certain date, detail that here. Remove if not needed-->

- [ ] Perequisites that must be completed before merging this pull request
