### PR TITLE
e2e debugging configuration for VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,28 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
+			"name": "Launch e2e tests",
+			"type": "go",
+			"request": "launch",
+			"mode": "test",
+			"program": "${workspaceFolder}/test/e2e",
+			"buildFlags": "-tags=e2e",
+
+			"args": [
+				"-test.count",
+				"1",
+				"-test.timeout",
+				"3600s",
+				"-test.v",
+				"verbose"
+			],
+			"env": {
+				"KUBECONFIG": "${workspaceFolder}/.kcp/admin.kubeconfig",
+				"CLUSTERS_KUBECONFIG_DIR": "${workspaceFolder}/tmp"
+			},
+			"envFile": "${workspaceFolder}/config/deploy/local/kcp-glbc/controller-config.env.ci"
+		},
+		{
 			"name": "Run KCP GLBC",
 			"type": "go",
 			"request": "launch",


### PR DESCRIPTION
## Description of Changes

* Add VS Code debugging configuration to debug e2e tests


## Release and Testing

* Locally, prepare the environment for e2e tests
    ```sh
    # Terminal 1
    make local-setup

    # Terminal 2
    (export $(cat ./config/deploy/local/kcp-glbc/controller-config.env.ci | xargs) && \
    KUBECONFIG=./tmp/kcp.kubeconfig ./bin/kcp-glbc)
    ```

* On VS Code, set a breakpoint in the e2e code and start debugging with the `Launch e2e tests` profile
* Verify that the e2e tests start and run as expected, and execution stops at the breakpoint    
    ![e2e-debug](https://user-images.githubusercontent.com/12643415/202489515-f4cde1dc-8485-44c4-8b3c-d7661d0fadf8.png)

