### PR TITLE
Inverse "ProviderSuccess" condition in DNS record and on route and ingress tests

### DIFF
--- a/pkg/apis/kuadrant/v1/types.go
+++ b/pkg/apis/kuadrant/v1/types.go
@@ -189,8 +189,8 @@ type DNSZoneStatus struct {
 }
 
 var (
-	// Failed means the record is not available within a zone.
-	DNSRecordFailedConditionType = "Failed"
+	// Succeeded means the record is available within a zone if the status condition is true.
+	DNSRecordSucceededConditionType = "Succeeded"
 )
 
 // DNSZoneCondition is just the standard condition fields.

--- a/pkg/traffic/dns.go
+++ b/pkg/traffic/dns.go
@@ -238,9 +238,8 @@ func foundNameserversOfDomainAndIP(host, managedHost string) bool {
 	} else {
 		for _, ns := range nameservers {
 			_ = dig.At(ns.Host)
-			a, err := dig.A(managedHost)
+			a, _ := dig.A(managedHost)
 			if a != nil {
-				fmt.Println(" A record and IP address found ", a, err)
 				found = true
 				break
 			}

--- a/test/e2e/ingress_test.go
+++ b/test/e2e/ingress_test.go
@@ -206,9 +206,9 @@ func TestIngress(t *testing.T) {
 			HaveKey(traffic.ANNOTATION_HCG_HOST),
 		)),
 		WithTransform(DNSRecordEndpoints, ContainElements(Endpoints(test, ingress, &resolver))),
-		WithTransform(DNSRecordCondition(zoneID, kuadrantv1.DNSRecordFailedConditionType), MatchFieldsP(IgnoreExtras,
+		WithTransform(DNSRecordCondition(zoneID, kuadrantv1.DNSRecordSucceededConditionType), MatchFieldsP(IgnoreExtras,
 			Fields{
-				"Status":  Equal("False"),
+				"Status":  Equal("True"),
 				"Reason":  Equal("ProviderSuccess"),
 				"Message": Equal("The DNS provider succeeded in ensuring the record"),
 			})),

--- a/test/e2e/route_test.go
+++ b/test/e2e/route_test.go
@@ -242,9 +242,9 @@ func TestRoute(t *testing.T) {
 		WithTransform(Annotations, And(
 			HaveKey(traffic.ANNOTATION_HCG_HOST),
 		)),
-		WithTransform(DNSRecordCondition(zoneID, kuadrantv1.DNSRecordFailedConditionType), MatchFieldsP(IgnoreExtras,
+		WithTransform(DNSRecordCondition(zoneID, kuadrantv1.DNSRecordSucceededConditionType), MatchFieldsP(IgnoreExtras,
 			Fields{
-				"Status":  Equal("False"),
+				"Status":  Equal("True"),
 				"Reason":  Equal("ProviderSuccess"),
 				"Message": Equal("The DNS provider succeeded in ensuring the record"),
 			})),

--- a/test/performance/dns_record_test.go
+++ b/test/performance/dns_record_test.go
@@ -92,9 +92,9 @@ func testDNSRecord(t Test, dnsRecordCount int, zoneID, glbcDomain string) {
 	for _, record := range dnsRecords {
 		t.Eventually(DNSRecord(t, namespace, record.Name)).Should(And(
 			WithTransform(DNSRecordEndpoints, HaveLen(1)),
-			WithTransform(DNSRecordCondition(zoneID, kuadrantv1.DNSRecordFailedConditionType), MatchFieldsP(IgnoreExtras,
+			WithTransform(DNSRecordCondition(zoneID, kuadrantv1.DNSRecordSucceededConditionType), MatchFieldsP(IgnoreExtras,
 				Fields{
-					"Status":  Equal("False"),
+					"Status":  Equal("True"),
 					"Reason":  Equal("ProviderSuccess"),
 					"Message": Equal("The DNS provider succeeded in ensuring the record"),
 				})),

--- a/test/smoke/basic_ingress.go
+++ b/test/smoke/basic_ingress.go
@@ -139,9 +139,9 @@ func TestIngressBasic(t Test, ingressCount int, zoneID, glbcDomain string) {
 			WithTransform(Annotations, And(
 				HaveKey(traffic.ANNOTATION_HCG_HOST),
 			)),
-			WithTransform(DNSRecordCondition(zoneID, kuadrantv1.DNSRecordFailedConditionType), MatchFieldsP(IgnoreExtras,
+			WithTransform(DNSRecordCondition(zoneID, kuadrantv1.DNSRecordSucceededConditionType), MatchFieldsP(IgnoreExtras,
 				Fields{
-					"Status":  Equal("False"),
+					"Status":  Equal("True"),
 					"Reason":  Equal("ProviderSuccess"),
 					"Message": Equal("The DNS provider succeeded in ensuring the record"),
 				})),


### PR DESCRIPTION
Closes #506 


## Description of Changes
- Added a "DNSRecordSucceededConditionType" which means the record is available within a zone.
- Removed "DNSRecordFailedConditionType"
- The status "True" in a DNSRecord now means it has succeeded. (Previously the status "False" in a DNSRecord would mean it had succeeded)