### PR TITLE
HCG-169

### DIFF
--- a/config/cluster-logging-operator/openshift/cluster-log-forwarder.yaml
+++ b/config/cluster-logging-operator/openshift/cluster-log-forwarder.yaml
@@ -1,0 +1,53 @@
+apiVersion: "logging.openshift.io/v1"
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  inputs:
+    - name: glbc
+      application:
+        namespaces:
+          - kcp-1276jyv7ca5w
+        selector:
+          matchLabels:
+            glbc-name: kcp-stable-redhat-hcg
+    - name: cert-manager
+      application:
+        namespaces:
+          - cert-manager
+        selector:
+          matchLabels:
+            app: cert-manager
+    - name: syncer-stable
+      application:
+        namespaces:
+          - kcp-syncer-glbc-19j0riab
+        selector:
+          matchLabels:
+            app: kcp-syncer-glbc-19j0riab
+    - name: syncer-unstable
+      application:
+        namespaces:
+          - kcp-syncer-glbc-2ig0nlzg
+        selector:
+          matchLabels:
+            app: kcp-syncer-glbc-2ig0nlzg
+  outputs:
+    - cloudwatch:
+        groupBy: namespaceName
+        groupPrefix: clo-logs
+        region: eu-west-1
+      name: cloudwatch
+      secret:
+        name: instance
+      type: cloudwatch
+  pipelines:
+    - inputRefs:
+        - glbc
+        - cert-manager
+        - syncer-stable
+        - syncer-unstable
+      name: pod-logs
+      outputRefs:
+        - cloudwatch

--- a/config/cluster-logging-operator/openshift/cluster-logging.yaml
+++ b/config/cluster-logging-operator/openshift/cluster-logging.yaml
@@ -1,0 +1,14 @@
+apiVersion: "logging.openshift.io/v1"
+kind: "ClusterLogging"
+metadata:
+  name: "instance"
+  namespace: "openshift-logging"
+spec:
+  managementState: "Managed"
+  collection:
+    logs:
+      fluentd:
+        resources:
+          requests:
+            memory: 736Mi
+      type: fluentd

--- a/config/cluster-logging-operator/openshift/kustomization.yaml
+++ b/config/cluster-logging-operator/openshift/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - subscription.yaml
+  - cluster-logging.yaml
+  - cluster-log-forwarder.yaml

--- a/config/cluster-logging-operator/openshift/subscription.yaml
+++ b/config/cluster-logging-operator/openshift/subscription.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  channel: stable-5.3
+  installPlanApproval: Automatic
+  name: cluster-logging
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: cluster-logging.5.3.14


### PR DESCRIPTION
Closes [HCG-169](https://issues.redhat.com/browse/HCG-169)


## Description of Changes
* Introduction of the Cluster Logging Operator 
* Used to collect logs from syncer (booth), glbc and cert-manager pods and forward them to the CloudWatch  


## Release and Testing
* Verify correct pods provide logs to the CLO (check the LogForwarder CR) 
* Verify collector pods are looking for pods (any collector pod logs)
* Verify logs are being stored in the CloudWatch (note - if pod haven't produced logs since the creation of the collector there will be no logs in the CloudWatch)


## Dependencies
Depends on [this](https://github.com/redhat-cps/glbc-deployments/pull/40) PR 
